### PR TITLE
perf(storage): Use ToListAsync() instead of ToArrayAsync()

### DIFF
--- a/src/Mocha.Core/Storage/Jaeger/IJaegerSpanReader.cs
+++ b/src/Mocha.Core/Storage/Jaeger/IJaegerSpanReader.cs
@@ -7,11 +7,11 @@ namespace Mocha.Core.Storage.Jaeger;
 
 public interface IJaegerSpanReader
 {
-    Task<string[]> GetServicesAsync();
+    Task<IEnumerable<string>> GetServicesAsync();
 
-    Task<string[]> GetOperationsAsync(string serviceName);
+    Task<IEnumerable<string>> GetOperationsAsync(string serviceName);
 
-    Task<JaegerTrace[]> FindTracesAsync(JaegerTraceQueryParameters query);
+    Task<IEnumerable<JaegerTrace>> FindTracesAsync(JaegerTraceQueryParameters query);
 
-    Task<JaegerTrace[]> FindTracesAsync(string[] traceIDs, ulong? startTimeMinUnixNano = null, ulong? startTimeMaxUnixNano = null);
+    Task<IEnumerable<JaegerTrace>> FindTracesAsync(string[] traceIDs, ulong? startTimeMinUnixNano = null, ulong? startTimeMaxUnixNano = null);
 }

--- a/tests/Mocha.Storage.Tests/EntityFrameworkCore/EFJaegerSpanReaderTests.cs
+++ b/tests/Mocha.Storage.Tests/EntityFrameworkCore/EFJaegerSpanReaderTests.cs
@@ -364,7 +364,7 @@ public class EFJaegerSpanReaderTests : IDisposable
             now.AddMinutes(-2).ToUnixTimeNanoseconds(),
             now.AddMinutes(2).ToUnixTimeNanoseconds());
         Assert.Single(traces);
-        Assert.Equal("TraceId1", traces[0].TraceID);
+        Assert.Equal("TraceId1", traces.First().TraceID);
     }
 
     public void Dispose()


### PR DESCRIPTION
- perf(storage): Use ToListAsync() instead of ToArrayAsync(), because ToArrayAsync() is a wrapper around ToListAsync().