### PR TITLE
chore: set Codecov patch coverage target to 97%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
         informational: true
     patch:
       default:
-        target: 98%
+        target: 97%
         threshold: 2%
         informational: false
 comment:


### PR DESCRIPTION
将 codecov.yml 中 patch coverage 的 target 从 98% 调整为 97%。