### PR TITLE
fix: eliminate MySQL readiness race in mysql-influxdb e2e

### DIFF
--- a/docker/docker-compose-mysql-influxdb.yml
+++ b/docker/docker-compose-mysql-influxdb.yml
@@ -21,6 +21,16 @@ services:
     volumes:
       - ../scripts/mysql/init:/docker-entrypoint-initdb.d/
 #      - ./mysql:/var/lib/mysql
+    # -h 127.0.0.1 forces a TCP connection, so this only turns healthy once the REAL server
+    # binds port 3306. During an empty first-init MySQL listens on the unix socket only (TCP
+    # port 0) for ~12s; a socket-based ping would pass too early and let dependents start
+    # against a server that is not yet accepting TCP.
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
     restart: always
     networks:
       - mocha
@@ -40,6 +50,11 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=mocha_influxdb_token
 #    volumes:
 #      - ./influxdb:/var/lib/influxdb2
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8086/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
     restart: always
     networks:
       - mocha
@@ -79,8 +94,10 @@ services:
       - Metrics__Storage__InfluxDB__Bucket=mocha_metrics
       - Logging__LogLevel__Microsoft.EntityFrameworkCore=Warning
     depends_on:
-      - mysql
-      - influxdb
+      mysql:
+        condition: service_healthy
+      influxdb:
+        condition: service_healthy
     restart: always
     networks:
       - mocha
@@ -107,8 +124,10 @@ services:
       - Metrics__Storage__InfluxDB__Bucket=mocha_metrics
       - Logging__LogLevel__Microsoft.EntityFrameworkCore=Warning
     depends_on:
-      - mysql
-      - influxdb
+      mysql:
+        condition: service_healthy
+      influxdb:
+        condition: service_healthy
     restart: always
     networks:
       - mocha

--- a/e2e/Mocha.E2E.Abstractions/OtlpSender.cs
+++ b/e2e/Mocha.E2E.Abstractions/OtlpSender.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Core Community under one or more agreements.
 // The .NET Core Community licenses this file to you under the MIT license.
 
+using Grpc.Core;
 using Grpc.Net.Client;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
 using OpenTelemetry.Proto.Collector.Trace.V1;
@@ -13,6 +14,14 @@ namespace Mocha.E2E.Abstractions;
 /// </summary>
 public sealed class OtlpSender : IDisposable
 {
+    // The distributor may still be finishing its own startup (opening its MySQL / InfluxDB
+    // connections) when the first case fires. During that window the gRPC channel reports
+    // Unavailable (connection refused / not yet listening). Retry the initial export for a
+    // short bounded window so a healthy-but-slow-starting distributor does not fail the run.
+    // This is defense-in-depth on top of the docker-compose healthcheck gating.
+    private static readonly TimeSpan _startupRetryWindow = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan _startupRetryDelay = TimeSpan.FromSeconds(1);
+
     private readonly GrpcChannel _channel;
     private readonly TraceService.TraceServiceClient _traceClient;
     private readonly MetricsService.MetricsServiceClient _metricsClient;
@@ -37,7 +46,9 @@ public sealed class OtlpSender : IDisposable
 
     public async Task SendTraceAsync(ExportTraceServiceRequest request, CancellationToken cancellationToken)
     {
-        var response = await _traceClient.ExportAsync(request, cancellationToken: cancellationToken);
+        var response = await SendWithStartupRetryAsync(
+            ct => _traceClient.ExportAsync(request, cancellationToken: ct).ResponseAsync,
+            cancellationToken);
         var rejected = response.PartialSuccess?.RejectedSpans ?? 0;
         if (rejected != 0)
         {
@@ -48,7 +59,9 @@ public sealed class OtlpSender : IDisposable
 
     public async Task SendMetricsAsync(ExportMetricsServiceRequest request, CancellationToken cancellationToken)
     {
-        var response = await _metricsClient.ExportAsync(request, cancellationToken: cancellationToken);
+        var response = await SendWithStartupRetryAsync(
+            ct => _metricsClient.ExportAsync(request, cancellationToken: ct).ResponseAsync,
+            cancellationToken);
         var rejected = response.PartialSuccess?.RejectedDataPoints ?? 0;
         if (rejected != 0)
         {
@@ -56,6 +69,33 @@ public sealed class OtlpSender : IDisposable
                 $"Distributor rejected {rejected} data point(s): {response.PartialSuccess?.ErrorMessage}");
         }
     }
+
+    /// <summary>
+    /// Invokes a gRPC export and retries while the channel reports a transient startup condition
+    /// (<see cref="StatusCode.Unavailable"/>, i.e. connection refused / not yet listening) for up
+    /// to <see cref="_startupRetryWindow"/>. Any other failure, or exhausting the window, rethrows
+    /// the last <see cref="RpcException"/>.
+    /// </summary>
+    private static async Task<TResponse> SendWithStartupRetryAsync<TResponse>(
+        Func<CancellationToken, Task<TResponse>> sendAsync,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTime.UtcNow + _startupRetryWindow;
+        while (true)
+        {
+            try
+            {
+                return await sendAsync(cancellationToken);
+            }
+            catch (RpcException ex) when (IsTransientStartup(ex.StatusCode) && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(_startupRetryDelay, cancellationToken);
+            }
+        }
+    }
+
+    private static bool IsTransientStartup(StatusCode statusCode) =>
+        statusCode is StatusCode.Unavailable or StatusCode.DeadlineExceeded;
 
     public void Dispose()
     {


### PR DESCRIPTION
## Problem
The Tier-1 full-stack `mysql-influxdb` e2e leg fails on CI (flaky; sometimes passed). Root cause: on CI, MySQL first-initializes from an empty data dir and listens only on its unix socket (~12s) before binding TCP 3306. The `distributor` eagerly connects to MySQL during host startup (`ServerVersion.AutoDetect` via the `StorageExporter` hosted service), throws, and `restart: always` crash-loops it. `run-e2e.sh`'s `wait_for_port` gets a false-positive from docker-proxy (host port bound immediately), so the OTLP sender fires into the crash-looping distributor and gets `Connection refused`. The litedb leg has no external DB, so it never races; Tier-2 (Testcontainers) also passes — confirming the storage adapters are fine and the issue is full-stack compose readiness.

## Fix
- `docker/docker-compose-mysql-influxdb.yml`: add healthchecks for `mysql` (`mysqladmin ping -h 127.0.0.1` — forces TCP so it only passes once the real server binds 3306, not the socket-only first-init server) and `influxdb` (`curl /health`), and change `distributor`/`query` to `depends_on: { condition: service_healthy }`. App containers (and thus docker-proxy binding `:4317`/`:5775`) no longer start until the databases truly accept connections.
- `e2e/Mocha.E2E.Abstractions/OtlpSender.cs`: bounded 30s retry on the initial OTLP export for gRPC `Unavailable`/`DeadlineExceeded` (defense-in-depth for the startup window).

No `src/` production code changed.

## Verification
Locally (real docker stack, mysql-influxdb): databases reach healthy before app containers start; all 4 containers `RestartCount=0`; distributor log clean (no `Unable to connect to any of the specified MySQL hosts`, no `Restarting`); e2e `2/2 case(s) passed`. This PR's CI run should show the E2E `mysql-influxdb` leg green.